### PR TITLE
Add React frontend for workflow grading

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,73 +1,12 @@
 <!DOCTYPE html>
-<html>
-<head>
-  <title>Submit Assignment for Grading</title>
-</head>
-<body>
-  <h1>Upload Files for Grading</h1>
-  <form id="gradingForm" enctype="multipart/form-data">
-    <label>Grader Name:</label><br>
-    <input type="text" name="graderName" required><br><br>
-
-    <label>Workflow:</label><br>
-    <select name="workflow" id="workflowSelect" required></select><br><br>
-
-    <label>Assignment File:</label><br>
-    <input type="file" name="assignmentFile" required><br><br>
-
-    <label>Solution File:</label><br>
-    <input type="file" name="solutionFile" required><br><br>
-
-    <label>Sample File:</label><br>
-    <input type="file" name="sampleFile" required><br><br>
-
-    <label>Rubrics File:</label><br>
-    <input type="file" name="rubricsFile" required><br><br>
-
-    <button type="submit">Submit for Grading</button>
-  </form>
-
-  <h3>Response:</h3>
-  <pre id="output" style="white-space: pre-wrap; background: #f0f0f0; padding: 1em; max-height: 500px; overflow-y: auto; border: 1px solid #ccc;"></pre>
-
-
-  <script>
-    async function loadWorkflows() {
-      try {
-        const res = await fetch("http://10.10.60.40:8080/api/workflows/");
-        const data = await res.json();
-        const select = document.getElementById("workflowSelect");
-
-        if (data.status === "success" && Array.isArray(data.workflows)) {
-          data.workflows.forEach(workflow => {
-            const option = document.createElement("option");
-            option.value = workflow;
-            option.text = workflow;
-            select.appendChild(option);
-          });
-        }
-      } catch (err) {
-        alert("⚠️ Failed to load workflows: " + err.message);
-      }
-    }
-
-    document.getElementById("gradingForm").addEventListener("submit", async function(e) {
-      e.preventDefault();
-      const formData = new FormData(this);
-      try {
-        const response = await fetch("http://10.10.60.40:8080/api/grade/", {
-          method: "POST",
-          body: formData
-        });
-        const result = await response.json();
-        document.getElementById("output").innerText = JSON.stringify(result, null, 2);
-      } catch (err) {
-        document.getElementById("output").innerText = "Request failed: " + err.message;
-      }
-    });
-
-    // Load workflows on page load
-    loadWorkflows();
-  </script>
-</body>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Autograder Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
 </html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "autograder-frontend",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.0",
+    "@types/react-dom": "^18.2.0",
+    "typescript": "^5.2.0",
+    "vite": "^4.4.9"
+    "@vitejs/plugin-react": "^4.2.0"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from 'react';
+
+interface WorkflowsResponse {
+  status: string;
+  workflows: string[];
+}
+
+type FileState = Record<string, File | null>;
+
+const API_BASE = import.meta.env.VITE_API_BASE ?? '';
+
+const App: React.FC = () => {
+  const [graderName, setGraderName] = useState('');
+  const [workflow, setWorkflow] = useState('');
+  const [workflows, setWorkflows] = useState<string[]>([]);
+  const [files, setFiles] = useState<FileState>({
+    assignmentFile: null,
+    solutionFile: null,
+    sampleFile: null,
+    rubricsFile: null
+  });
+  const [output, setOutput] = useState('');
+
+  useEffect(() => {
+    fetch(`${API_BASE}/api/workflows/`)
+      .then((res) => res.json())
+      .then((data: WorkflowsResponse) => {
+        if (data.status === 'success') {
+          setWorkflows(data.workflows);
+          if (data.workflows.length > 0) {
+            setWorkflow(data.workflows[0]);
+          }
+        }
+      })
+      .catch((err) => {
+        console.error('Failed to load workflows', err);
+      });
+  }, []);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setFiles({ ...files, [e.target.name]: e.target.files?.[0] ?? null });
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const formData = new FormData();
+    formData.append('graderName', graderName);
+    formData.append('workflow', workflow);
+    Object.entries(files).forEach(([key, file]) => {
+      if (file) {
+        formData.append(key, file);
+      }
+    });
+
+    try {
+      const res = await fetch(`${API_BASE}/api/grade/`, {
+        method: 'POST',
+        body: formData
+      });
+      const result = await res.json();
+      setOutput(JSON.stringify(result, null, 2));
+    } catch (err: any) {
+      setOutput('Request failed: ' + err.message);
+    }
+  };
+
+  return (
+    <div className="container">
+      <h1>Upload Files for Grading</h1>
+      <form className="grading-form" onSubmit={handleSubmit}>
+        <label>Grader Name</label>
+        <input
+          type="text"
+          value={graderName}
+          onChange={(e) => setGraderName(e.target.value)}
+          required
+        />
+
+        <label>Workflow</label>
+        <select value={workflow} onChange={(e) => setWorkflow(e.target.value)} required>
+          {workflows.map((w) => (
+            <option key={w} value={w}>
+              {w}
+            </option>
+          ))}
+        </select>
+
+        <label>Assignment File</label>
+        <input type="file" name="assignmentFile" onChange={handleFileChange} required />
+
+        <label>Solution File</label>
+        <input type="file" name="solutionFile" onChange={handleFileChange} required />
+
+        <label>Sample File</label>
+        <input type="file" name="sampleFile" onChange={handleFileChange} required />
+
+        <label>Rubrics File</label>
+        <input type="file" name="rubricsFile" onChange={handleFileChange} required />
+
+        <button type="submit">Submit for Grading</button>
+      </form>
+
+      <h3>Response</h3>
+      <pre className="output">{output}</pre>
+    </div>
+  );
+};
+
+export default App;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './styles.css';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(
+    <React.StrictMode>
+      <App />
+    </React.StrictMode>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,48 @@
+:root {
+  --primary-color: #4f46e5;
+  --background: #ffffff;
+  --text-color: #333;
+  --border-radius: 4px;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, sans-serif;
+  background: var(--background);
+  color: var(--text-color);
+}
+
+.container {
+  max-width: 600px;
+  margin: 2rem auto;
+  padding: 1rem;
+}
+
+.grading-form {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.grading-form input,
+.grading-form select {
+  padding: 0.5rem;
+  border: 1px solid #ccc;
+  border-radius: var(--border-radius);
+}
+
+.grading-form button {
+  padding: 0.75rem;
+  background: var(--primary-color);
+  color: #fff;
+  border: none;
+  border-radius: var(--border-radius);
+  cursor: pointer;
+}
+
+.output {
+  background: #f4f4f4;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  max-height: 400px;
+  overflow-y: auto;
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 3000
+  }
+});


### PR DESCRIPTION
## Summary
- replace static HTML form with a React-based app
- fetch workflows from the backend and submit grading requests
- add Vite/TypeScript config and basic styling for customization

## Testing
- `npm test` *(fails: no test script defined)*