### PR TITLE
Add simple website with navigation

### DIFF
--- a/frontend/components/Layout.tsx
+++ b/frontend/components/Layout.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link';
+import React, { ReactNode } from 'react';
+import styles from '../styles/layout.module.css';
+
+interface LayoutProps {
+  children: ReactNode;
+}
+
+const Layout: React.FC<LayoutProps> = ({ children }) => (
+  <>
+    <header className={styles.header}>
+      <div className={styles.logo}>EdGenAI - Education with Generative AI</div>
+      <nav>
+        <ul className={styles.navList}>
+          <li>
+            <Link href="/">Home</Link>
+          </li>
+          <li>
+            <Link href="/services">Services</Link>
+          </li>
+          <li>
+            <Link href="/contact">Contact Us</Link>
+          </li>
+        </ul>
+      </nav>
+    </header>
+    <main className={styles.main}>{children}</main>
+    <footer className={styles.footer}>
+      &copy; {new Date().getFullYear()} EdGenAI
+    </footer>
+  </>
+);
+
+export default Layout;

--- a/frontend/pages/autograder.tsx
+++ b/frontend/pages/autograder.tsx
@@ -1,0 +1,10 @@
+import App from '../components/App';
+import Layout from '../components/Layout';
+
+export default function AutoGraderPage() {
+  return (
+    <Layout>
+      <App />
+    </Layout>
+  );
+}

--- a/frontend/pages/contact.tsx
+++ b/frontend/pages/contact.tsx
@@ -1,0 +1,10 @@
+import Layout from '../components/Layout';
+
+export default function Contact() {
+  return (
+    <Layout>
+      <h1>Contact Us</h1>
+      <p>Email: contact@edgenai.com</p>
+    </Layout>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,5 +1,19 @@
-import App from '../components/App';
+import Layout from '../components/Layout';
+import Link from 'next/link';
 
 export default function Home() {
-  return <App />;
+  return (
+    <Layout>
+      <h1>Welcome to EdGenAI</h1>
+      <p>
+        EdGenAI's Auto Grader leverages Generative AI to streamline the grading
+        process. Upload your assignments and let our models provide fast and
+        consistent feedback for every submission.
+      </p>
+      <p>
+        Explore our <Link href="/services">services</Link> to learn more about
+        what we offer.
+      </p>
+    </Layout>
+  );
 }

--- a/frontend/pages/project-planner.tsx
+++ b/frontend/pages/project-planner.tsx
@@ -1,0 +1,10 @@
+import Layout from '../components/Layout';
+
+export default function ProjectPlanner() {
+  return (
+    <Layout>
+      <h1>Project Planner</h1>
+      <p>Coming soon...</p>
+    </Layout>
+  );
+}

--- a/frontend/pages/services.tsx
+++ b/frontend/pages/services.tsx
@@ -1,0 +1,18 @@
+import Layout from '../components/Layout';
+import Link from 'next/link';
+
+export default function Services() {
+  return (
+    <Layout>
+      <h1>Our Services</h1>
+      <ul>
+        <li>
+          <Link href="/autograder">Auto Grader</Link>
+        </li>
+        <li>
+          <Link href="/project-planner">Project Planner</Link>
+        </li>
+      </ul>
+    </Layout>
+  );
+}

--- a/frontend/styles/layout.module.css
+++ b/frontend/styles/layout.module.css
@@ -1,0 +1,38 @@
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: var(--primary-color);
+  color: #fff;
+}
+
+.logo {
+  font-weight: bold;
+}
+
+.navList {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.navList li a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.main {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+.footer {
+  text-align: center;
+  padding: 1rem;
+  background: #f2f2f2;
+  color: var(--text-color);
+}


### PR DESCRIPTION
## Summary
- add Layout component with navigation links
- implement landing pages for home, services, contact, project planner, and autograder
- style header and footer

## Testing
- `npm install` *(fails: network access required)*
- `pytest` *(fails: command not found)*