### PR TITLE
Add static pages and updated Home text

### DIFF
--- a/docs/autograder.html
+++ b/docs/autograder.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>EdGenAI - Home</title>
+  <title>EdGenAI - Auto Grader</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -17,13 +17,8 @@
     </nav>
   </header>
   <main>
-    <h1>Welcome to EdGenAI</h1>
-    <p>
-      EdGenAI's Auto Grader harnesses the power of Generative AI to streamline
-      assignment grading. Upload your coursework and receive consistent,
-      detailed feedback in minutes rather than days.
-    </p>
-    <p>Explore our <a href="services.html">services</a> to learn more.</p>
+    <h1>Auto Grader</h1>
+    <p>The Auto Grader application is available at <a href="/autograder">/autograder</a>.</p>
   </main>
   <footer>
     &copy; <span id="year"></span> EdGenAI

--- a/docs/contact.html
+++ b/docs/contact.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>EdGenAI - Home</title>
+  <title>EdGenAI - Contact Us</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -17,13 +17,8 @@
     </nav>
   </header>
   <main>
-    <h1>Welcome to EdGenAI</h1>
-    <p>
-      EdGenAI's Auto Grader harnesses the power of Generative AI to streamline
-      assignment grading. Upload your coursework and receive consistent,
-      detailed feedback in minutes rather than days.
-    </p>
-    <p>Explore our <a href="services.html">services</a> to learn more.</p>
+    <h1>Contact Us</h1>
+    <p>Email: <a href="mailto:contact@edgenai.com">contact@edgenai.com</a></p>
   </main>
   <footer>
     &copy; <span id="year"></span> EdGenAI

--- a/docs/project-planner.html
+++ b/docs/project-planner.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>EdGenAI - Home</title>
+  <title>EdGenAI - Project Planner</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -17,13 +17,8 @@
     </nav>
   </header>
   <main>
-    <h1>Welcome to EdGenAI</h1>
-    <p>
-      EdGenAI's Auto Grader harnesses the power of Generative AI to streamline
-      assignment grading. Upload your coursework and receive consistent,
-      detailed feedback in minutes rather than days.
-    </p>
-    <p>Explore our <a href="services.html">services</a> to learn more.</p>
+    <h1>Project Planner</h1>
+    <p>Coming soon...</p>
   </main>
   <footer>
     &copy; <span id="year"></span> EdGenAI

--- a/docs/services.html
+++ b/docs/services.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
-  <title>EdGenAI - Home</title>
+  <title>EdGenAI - Services</title>
   <link rel="stylesheet" href="styles.css" />
 </head>
 <body>
@@ -17,13 +17,11 @@
     </nav>
   </header>
   <main>
-    <h1>Welcome to EdGenAI</h1>
-    <p>
-      EdGenAI's Auto Grader harnesses the power of Generative AI to streamline
-      assignment grading. Upload your coursework and receive consistent,
-      detailed feedback in minutes rather than days.
-    </p>
-    <p>Explore our <a href="services.html">services</a> to learn more.</p>
+    <h1>Our Services</h1>
+    <ul>
+      <li><a href="/autograder">Auto Grader</a></li>
+      <li><a href="/project-planner">Project Planner</a></li>
+    </ul>
   </main>
   <footer>
     &copy; <span id="year"></span> EdGenAI

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -1,0 +1,45 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  background: #ffffff;
+  color: #333;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1rem 2rem;
+  background: #4f46e5;
+  color: #fff;
+}
+
+header .logo {
+  font-weight: bold;
+}
+
+.nav-list {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+}
+
+.nav-list a {
+  color: #fff;
+  text-decoration: none;
+}
+
+main {
+  max-width: 900px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background: #f2f2f2;
+  color: #333;
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -6,9 +6,13 @@ export default function Home() {
     <Layout>
       <h1>Welcome to EdGenAI</h1>
       <p>
-        EdGenAI's Auto Grader leverages Generative AI to streamline the grading
-        process. Upload your assignments and let our models provide fast and
-        consistent feedback for every submission.
+        At EdGenAI we harness Generative AI to transform the learning experience
+        for both students and instructors.
+      </p>
+      <p>
+        Our flagship <strong>Auto Grader</strong> automates the grading workflow,
+        providing consistent and detailed feedback within minutes. Simply upload
+        your assignment files and let our models handle the rest.
       </p>
       <p>
         Explore our <Link href="/services">services</Link> to learn more about


### PR DESCRIPTION
## Summary
- add production-grade HTML pages in `docs/` with navigation for Home, Services, Contact Us
- include placeholder pages for Auto Grader and Project Planner
- add shared styles for the static site
- improve text on the Next.js home page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_683baa9deeac8330b418c2edc6596b2d