### PR TITLE
Improve front‑end layout and add services page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { Route, Routes } from 'react-router-dom';
 import Home from './pages/Home';
 import Products from './pages/Products';
+import Services from './pages/Services';
 import Contact from './pages/Contact';
 import RequestAccess from './pages/RequestAccess';
 import Header from './components/Header';
@@ -13,6 +14,7 @@ export default function App() {
       <main>
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route path="/services" element={<Services />} />
           <Route path="/products" element={<Products />} />
           <Route path="/contact" element={<Contact />} />
           <Route path="/request-access" element={<RequestAccess />} />

--- a/frontend/src/components/Header.css
+++ b/frontend/src/components/Header.css
@@ -10,15 +10,32 @@
   z-index: 10;
 }
 
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.logo {
+  font-weight: bold;
+  text-decoration: none;
+  color: #fff;
+}
+
 .nav a {
   margin-right: 1rem;
   color: #fff;
   text-decoration: none;
   font-weight: 500;
+  transition: opacity 0.2s;
 }
 
 .nav a:last-child {
   margin-right: 0;
+}
+
+.nav a:hover {
+  opacity: 0.8;
 }
 
 .request-button {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -4,9 +4,10 @@ import './Header.css';
 export default function Header() {
   return (
     <header className="header">
-      <div className="logo">EdGenAI</div>
+      <Link to="/" className="logo">EdGenAI</Link>
       <nav className="nav">
         <Link to="/">Home</Link>
+        <Link to="/services">Services</Link>
         <Link to="/products">Products</Link>
         <Link to="/contact">Contact Us</Link>
       </nav>

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -10,7 +10,7 @@
   justify-content: center;
 }
 
-.offerings, .why {
+.services, .home-products, .why {
   margin-top: 3rem;
 }
 
@@ -27,6 +27,34 @@
   padding: 1rem;
   border-radius: 6px;
   text-align: center;
+}
+
+.grid li a {
+  color: inherit;
+  text-decoration: none;
+  display: block;
+}
+
+.video {
+  margin-top: 2rem;
+  text-align: center;
+}
+
+.video-placeholder {
+  background: #d1d5db;
+  height: 0;
+  padding-bottom: 56.25%;
+  position: relative;
+  border-radius: 6px;
+}
+
+.video-placeholder::after {
+  content: 'Demo Video';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #374151;
 }
 
 .cta {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -13,15 +13,25 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="offerings">
-        <h2>Our Offerings</h2>
+      <section className="video">
+        <h2>Platform Demo</h2>
+        <div className="video-placeholder">Demo Video Placeholder</div>
+      </section>
+      <section className="services">
+        <h2>Our Services</h2>
         <ul className="grid">
-          <li>GenAI Consultancy</li>
-          <li>Content Design</li>
-          <li>Authentic Assignment Design</li>
-          <li>Course Design</li>
-          <li>Auto Grade</li>
-          <li>Plan My Assignments</li>
+          <li><Link to="/services#consultancy">GenAI Consultancy</Link></li>
+          <li><Link to="/services#content-design">Content Design</Link></li>
+          <li><Link to="/services#authentic">Authentic Assignment Design</Link></li>
+          <li><Link to="/services#course-design">Course Design</Link></li>
+        </ul>
+      </section>
+
+      <section className="home-products">
+        <h2>Our Products</h2>
+        <ul className="grid">
+          <li><Link to="/products#auto-grade">Auto Grade</Link></li>
+          <li><Link to="/products#plan-my-assignments">Plan My Assignments</Link></li>
         </ul>
       </section>
 

--- a/frontend/src/pages/Products.css
+++ b/frontend/src/pages/Products.css
@@ -23,3 +23,21 @@
   list-style: disc inside;
   margin-bottom: 1rem;
 }
+
+.video-placeholder {
+  background: #d1d5db;
+  height: 0;
+  padding-bottom: 56.25%;
+  position: relative;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+}
+
+.video-placeholder::after {
+  content: 'Demo Video';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  color: #374151;
+}

--- a/frontend/src/pages/Products.tsx
+++ b/frontend/src/pages/Products.tsx
@@ -7,7 +7,7 @@ export default function Products() {
       <h1>Our Products</h1>
       <p className="subtitle">Purpose-built AI tools for modern education.</p>
 
-      <section className="product">
+      <section id="auto-grade" className="product">
         <h2>Auto Grade</h2>
         <ul>
           <li>AI-powered grading</li>
@@ -15,16 +15,18 @@ export default function Products() {
           <li>Batch processing</li>
           <li>Transparent feedback</li>
         </ul>
+        <div className="video-placeholder">Demo Video</div>
         <Link to="/request-access" className="btn-primary">Request Access</Link>
       </section>
 
-      <section className="product">
+      <section id="plan-my-assignments" className="product">
         <h2>Plan My Assignments</h2>
         <ul>
           <li>Assignment planning</li>
           <li>Learning outcome mapping</li>
           <li>AI-generated scaffolding</li>
         </ul>
+        <div className="video-placeholder">Demo Video</div>
         <Link to="/request-access" className="btn-primary">Request Access</Link>
       </section>
     </div>

--- a/frontend/src/pages/Services.css
+++ b/frontend/src/pages/Services.css
@@ -1,0 +1,15 @@
+.services h1 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.service {
+  margin-bottom: 2rem;
+  background: #eef2ff;
+  padding: 1rem;
+  border-radius: 6px;
+}
+
+.service h2 {
+  margin-top: 0;
+}

--- a/frontend/src/pages/Services.tsx
+++ b/frontend/src/pages/Services.tsx
@@ -1,0 +1,25 @@
+import './Services.css';
+
+export default function Services() {
+  return (
+    <div className="container services">
+      <h1>Our Services</h1>
+      <section id="consultancy" className="service">
+        <h2>GenAI Consultancy</h2>
+        <p>Expert guidance on integrating generative AI into your institution.</p>
+      </section>
+      <section id="content-design" className="service">
+        <h2>Content Design</h2>
+        <p>Engaging learning materials crafted with AI-powered tools.</p>
+      </section>
+      <section id="authentic" className="service">
+        <h2>Authentic Assignment Design</h2>
+        <p>Assignments that promote creativity and deeper learning.</p>
+      </section>
+      <section id="course-design" className="service">
+        <h2>Course Design</h2>
+        <p>Turnkey course solutions built with AI-driven insights.</p>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- make header logo link to home and add Services link
- add hover styling and responsive nav
- reorganize Home page with Services and Products sections
- include demo video placeholders on Home and Products pages
- create dedicated Services page
- update routes and product page styling

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_6843f668edcc83309f89f8d839f0061d