### PR TITLE
Improve home page sections

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -25,6 +25,9 @@ export default function Header() {
       </button>
 
       <nav className={`nav ${mobileOpen ? 'open' : ''}`}>
+        <Link to="/" className="nav-link" onClick={closeMenus}>
+          Home
+        </Link>
         <div
           className="nav-item"
           onMouseEnter={() => setOpenMenu('why')}

--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -1,6 +1,15 @@
 .hero {
   text-align: center;
-  padding: 4rem 1rem;
+  padding: 3rem 1rem;
+  width: 100%;
+}
+
+.hero h1 {
+  font-size: clamp(2rem, 5vw, 4rem);
+}
+
+.hero p {
+  font-size: clamp(1rem, 2.5vw, 1.5rem);
 }
 
 .hero-actions {
@@ -35,7 +44,7 @@
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
 }
 .success-section {
-  margin-top: 3rem;
+  margin-top: 2rem;
   text-align: center;
 }
 

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -41,10 +41,10 @@ export default function Home() {
       <section className="products-section container">
         <h2>Our Products</h2>
         <div className="cards">
-          <div className="card">
+          <div className="card link-card">
             <h3>Auto Grade</h3>
           </div>
-          <div className="card">
+          <div className="card link-card">
             <h3>Plan My Assignment</h3>
           </div>
         </div>
@@ -53,9 +53,9 @@ export default function Home() {
       <section className="why-section container">
         <h2>Why Choose EdGenAI?</h2>
         <div className="cards">
-          <div className="card">GenAI for Authentic Learning</div>
-          <div className="card">Transparency and Modular</div>
-          <div className="card">Privacy and Security Focus</div>
+          <div className="card link-card">GenAI for Authentic Learning</div>
+          <div className="card link-card">Transparency and Modular</div>
+          <div className="card link-card">Privacy and Security Focus</div>
         </div>
       </section>
 

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -15,6 +15,11 @@ main {
 
 h1, h2, h3 {
   color: #111827;
+  margin: 0;
+}
+
+section {
+  padding: 2rem 0;
 }
 
 .container {


### PR DESCRIPTION
## Summary
- add Home link in header navigation
- reduce hero and section padding
- remove heading margins for tighter spacing

## Testing
- `npm --prefix frontend run build`


------
https://chatgpt.com/codex/tasks/task_b_6844071747408330b850b4c15106e205