### PR TITLE
Improve frontend layout and navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,6 +4,8 @@ import Products from './pages/Products';
 import Services from './pages/Services';
 import Contact from './pages/Contact';
 import RequestAccess from './pages/RequestAccess';
+import WhyEdGenAI from './pages/WhyEdGenAI';
+import SuccessStories from './pages/SuccessStories';
 import Header from './components/Header';
 import Footer from './components/Footer';
 
@@ -17,6 +19,8 @@ export default function App() {
           <Route path="/services" element={<Services />} />
           <Route path="/products" element={<Products />} />
           <Route path="/contact" element={<Contact />} />
+          <Route path="/why-edgenai" element={<WhyEdGenAI />} />
+          <Route path="/success-stories" element={<SuccessStories />} />
           <Route path="/request-access" element={<RequestAccess />} />
         </Routes>
       </main>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -32,7 +32,9 @@ export default function Header() {
           className="nav-item"
           onMouseEnter={() => setOpenMenu('why')}
         >
-          <span className="nav-link">Why EdGenAI</span>
+          <Link to="/why-edgenai" className="nav-link" onClick={closeMenus}>
+            Why EdGenAI
+          </Link>
           <div className={`dropdown ${openMenu === 'why' ? 'open' : ''}`}>
             <Link to="/mission">Mission</Link>
             <Link to="/how-we-work">How We Work</Link>
@@ -71,7 +73,9 @@ export default function Header() {
           className="nav-item"
           onMouseEnter={() => setOpenMenu('success')}
         >
-          <span className="nav-link">Success Stories</span>
+          <Link to="/success-stories" className="nav-link" onClick={closeMenus}>
+            Success Stories
+          </Link>
           <div className={`dropdown ${openMenu === 'success' ? 'open' : ''}`}>
             <Link to="/case-studies">Case Studies</Link>
             <Link to="/testimonials">Testimonials</Link>

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -20,7 +20,7 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="services-section container">
+      <section className="services-section container page-section">
         <h2>Our Services</h2>
         <div className="cards service-cards">
           <Link to="/services#consultancy" className="card link-card">
@@ -38,7 +38,7 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="products-section container">
+      <section className="products-section container page-section">
         <h2>Our Products</h2>
         <div className="cards">
           <div className="card link-card">
@@ -50,7 +50,7 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="why-section container">
+      <section className="why-section container page-section">
         <h2>Why Choose EdGenAI?</h2>
         <div className="cards">
           <div className="card link-card">GenAI for Authentic Learning</div>
@@ -59,7 +59,7 @@ export default function Home() {
         </div>
       </section>
 
-      <section className="success-section container">
+      <section className="success-section container page-section">
         <h2>Success Stories</h2>
         <div className="testimonials">Logos / Testimonials Placeholder</div>
       </section>

--- a/frontend/src/pages/Products.css
+++ b/frontend/src/pages/Products.css
@@ -9,7 +9,6 @@
 }
 
 .product {
-  margin-bottom: 2rem;
   background: #eef2ff;
   padding: 1rem;
   border-radius: 6px;

--- a/frontend/src/pages/Products.tsx
+++ b/frontend/src/pages/Products.tsx
@@ -7,7 +7,7 @@ export default function Products() {
       <h1>Our Products</h1>
       <p className="subtitle">Purpose-built AI tools for modern education.</p>
 
-      <section id="auto-grade" className="product">
+      <section id="auto-grade" className="product page-section">
         <h2>Auto Grade</h2>
         <ul>
           <li>AI-powered grading</li>
@@ -19,7 +19,7 @@ export default function Products() {
         <Link to="/request-access" className="btn-primary">Request Access</Link>
       </section>
 
-      <section id="plan-my-assignments" className="product">
+      <section id="plan-my-assignments" className="product page-section">
         <h2>Plan My Assignments</h2>
         <ul>
           <li>Assignment planning</li>

--- a/frontend/src/pages/Services.css
+++ b/frontend/src/pages/Services.css
@@ -4,7 +4,6 @@
 }
 
 .service {
-  margin-bottom: 2rem;
   background: #eef2ff;
   padding: 1rem;
   border-radius: 6px;

--- a/frontend/src/pages/Services.tsx
+++ b/frontend/src/pages/Services.tsx
@@ -4,19 +4,19 @@ export default function Services() {
   return (
     <div className="container services">
       <h1>Our Services</h1>
-      <section id="consultancy" className="service">
+      <section id="consultancy" className="service page-section">
         <h2>GenAI Consultancy</h2>
         <p>Expert guidance on integrating generative AI into your institution.</p>
       </section>
-      <section id="content-design" className="service">
+      <section id="content-design" className="service page-section">
         <h2>Content Design</h2>
         <p>Engaging learning materials crafted with AI-powered tools.</p>
       </section>
-      <section id="authentic" className="service">
+      <section id="authentic" className="service page-section">
         <h2>Authentic Assignment Design</h2>
         <p>Assignments that promote creativity and deeper learning.</p>
       </section>
-      <section id="course-design" className="service">
+      <section id="course-design" className="service page-section">
         <h2>Course Design</h2>
         <p>Turnkey course solutions built with AI-driven insights.</p>
       </section>

--- a/frontend/src/pages/SuccessStories.css
+++ b/frontend/src/pages/SuccessStories.css
@@ -1,0 +1,12 @@
+.success-page h1 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.page-section {
+  margin-top: 2rem;
+}
+
+.page-section h2 {
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/pages/SuccessStories.tsx
+++ b/frontend/src/pages/SuccessStories.tsx
@@ -1,0 +1,17 @@
+import './SuccessStories.css';
+
+export default function SuccessStories() {
+  return (
+    <div className="container success-page">
+      <h1>Success Stories</h1>
+      <section className="page-section">
+        <h2>Case Studies</h2>
+        <p>Discover how institutions benefited from EdGenAI.</p>
+      </section>
+      <section className="page-section">
+        <h2>Testimonials</h2>
+        <p>Hear directly from educators using our tools.</p>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/WhyEdGenAI.css
+++ b/frontend/src/pages/WhyEdGenAI.css
@@ -1,0 +1,12 @@
+.why-page h1 {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
+.page-section {
+  margin-top: 2rem;
+}
+
+.page-section h2 {
+  margin-bottom: 0.5rem;
+}

--- a/frontend/src/pages/WhyEdGenAI.tsx
+++ b/frontend/src/pages/WhyEdGenAI.tsx
@@ -1,0 +1,21 @@
+import './WhyEdGenAI.css';
+
+export default function WhyEdGenAI() {
+  return (
+    <div className="container why-page">
+      <h1>Why EdGenAI</h1>
+      <section className="page-section">
+        <h2>Mission</h2>
+        <p>Our mission is to empower educators with transparent AI tools.</p>
+      </section>
+      <section className="page-section">
+        <h2>How We Work</h2>
+        <p>We collaborate closely with institutions to integrate GenAI effectively.</p>
+      </section>
+      <section className="page-section">
+        <h2>AI Principles</h2>
+        <p>Privacy, modularity and authentic learning are at our core.</p>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -43,3 +43,9 @@ button {
 .btn-primary:hover {
   background: #4338ca;
 }
+
+.page-section {
+  margin-top: 2rem;
+  padding-top: 2rem;
+  border-top: 1px solid #e5e7eb;
+}


### PR DESCRIPTION
## Summary
- add new pages for Why EdGenAI and Success Stories
- make nav tabs clickable and keep dropdown menus
- create a reusable `page-section` style for better spacing
- apply spacing sections on home, products and services pages
- hook up new routes

## Testing
- `npm run build`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68440d3b378c8330a356d1174801b3c8