### PR TITLE
Make home page cards navigable

### DIFF
--- a/frontend/src/pages/Home.css
+++ b/frontend/src/pages/Home.css
@@ -37,6 +37,7 @@
   text-decoration: none;
   color: inherit;
   transition: transform 0.2s, box-shadow 0.2s;
+  cursor: pointer;
 }
 
 .link-card:hover {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -41,27 +41,35 @@ export default function Home() {
       <section className="products-section container page-section">
         <h2>Our Products</h2>
         <div className="cards">
-          <div className="card link-card">
+          <Link to="/products#auto-grade" className="card link-card">
             <h3>Auto Grade</h3>
-          </div>
-          <div className="card link-card">
+          </Link>
+          <Link to="/products#plan-my-assignments" className="card link-card">
             <h3>Plan My Assignment</h3>
-          </div>
+          </Link>
         </div>
       </section>
 
       <section className="why-section container page-section">
         <h2>Why Choose EdGenAI?</h2>
         <div className="cards">
-          <div className="card link-card">GenAI for Authentic Learning</div>
-          <div className="card link-card">Transparency and Modular</div>
-          <div className="card link-card">Privacy and Security Focus</div>
+          <Link to="/why-edgenai#mission" className="card link-card">
+            GenAI for Authentic Learning
+          </Link>
+          <Link to="/why-edgenai#how-we-work" className="card link-card">
+            Transparency and Modular
+          </Link>
+          <Link to="/why-edgenai#ai-principles" className="card link-card">
+            Privacy and Security Focus
+          </Link>
         </div>
       </section>
 
       <section className="success-section container page-section">
         <h2>Success Stories</h2>
-        <div className="testimonials">Logos / Testimonials Placeholder</div>
+        <Link to="/success-stories" className="testimonials link-card">
+          Logos / Testimonials Placeholder
+        </Link>
       </section>
     </div>
   );

--- a/frontend/src/pages/WhyEdGenAI.tsx
+++ b/frontend/src/pages/WhyEdGenAI.tsx
@@ -4,15 +4,15 @@ export default function WhyEdGenAI() {
   return (
     <div className="container why-page">
       <h1>Why EdGenAI</h1>
-      <section className="page-section">
+      <section id="mission" className="page-section">
         <h2>Mission</h2>
         <p>Our mission is to empower educators with transparent AI tools.</p>
       </section>
-      <section className="page-section">
+      <section id="how-we-work" className="page-section">
         <h2>How We Work</h2>
         <p>We collaborate closely with institutions to integrate GenAI effectively.</p>
       </section>
-      <section className="page-section">
+      <section id="ai-principles" className="page-section">
         <h2>AI Principles</h2>
         <p>Privacy, modularity and authentic learning are at our core.</p>
       </section>


### PR DESCRIPTION
## Summary
- add links for product and info cards on the Home page
- link success stories block to its page
- expose section anchors on the Why EdGenAI page
- add pointer cursor for cards

## Testing
- `npm run build`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684410cdf474833093027b93472688c3